### PR TITLE
Use latest Winetricks + manually download msxml6 to avoid occasional …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y whiptail setools lzip wine winetricks patchelf e2fsprogs python3-pip aria2 p7zip-full attr
+          sudo apt-get install -y whiptail setools lzip wine patchelf e2fsprogs python3-pip aria2 p7zip-full attr
+          sudo wget https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks -P /usr/local/bin/
+          sudo chmod +x /usr/local/bin/winetricks
+          wget https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/wine/.cache/winetricks/msxml6/msxml6-KB973686-enu-amd64.exe -P /home/runner/.cache/winetricks/msxml6/
           pip list --disable-pip-version-check | grep -E "^requests " >/dev/null 2>&1 || python3 -m pip install requests
           winetricks list-installed | grep -E "^msxml6" >/dev/null 2>&1 || winetricks msxml6 || abort
        

--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -56,7 +56,10 @@ jobs:
       - name: Install Dependencies 🧑‍🏭
         run: |
           sudo apt-get update
-          sudo apt-get install -y whiptail setools lzip wine winetricks patchelf e2fsprogs python3-pip aria2 p7zip-full attr
+          sudo apt-get install -y whiptail setools lzip wine patchelf e2fsprogs python3-pip aria2 p7zip-full attr
+          sudo wget https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks -P /usr/local/bin/
+          sudo chmod +x /usr/local/bin/winetricks
+          wget https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/wine/.cache/winetricks/msxml6/msxml6-KB973686-enu-amd64.exe -P /home/runner/.cache/winetricks/msxml6/
           pip list --disable-pip-version-check | grep -E "^requests " >/dev/null 2>&1 || python3 -m pip install requests
           winetricks list-installed | grep -E "^msxml6" >/dev/null 2>&1 || winetricks msxml6 || abort
       


### PR DESCRIPTION
…download falling

- By default, Winetricks package provided within Ubuntu is pretty old. We can use the latest version from their official GitHub repo.

- Sometimes, msxml6 fails to download, I mean it fails to download the msxml6's URL mentioned in Winetricks. But we have the msxml6 available in this repo. So, therefore, download msxml6 we have in order to avoid occasional download falling.