### PR TITLE
Miscellaneous changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,36 +20,38 @@ jobs:
         root: [magisk, none]
         gapps: [MindTheGapps, none]
         release: [retail]
-        
-    steps:         
+        compress-format: [7z]
+
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+
       - name: Install Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y whiptail setools lzip wine winetricks patchelf e2fsprogs python3-pip aria2 p7zip-full attr
+          sudo apt-get update -y
+          sudo apt-get install -y whiptail setools lzip wine patchelf e2fsprogs python3-pip aria2 p7zip-full attr xz-utils unzip cabextract
+          sudo wget -P /usr/local/bin/ https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
+          sudo chmod +x /usr/local/bin/winetricks
+          wget -P /home/runner/.cache/winetricks/msxml6/ https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/wine/.cache/winetricks/msxml6/msxml6-KB973686-enu-amd64.exe
           pip list --disable-pip-version-check | grep -E "^requests " >/dev/null 2>&1 || python3 -m pip install requests
           winetricks list-installed | grep -E "^msxml6" >/dev/null 2>&1 || winetricks msxml6 || abort
-       
+
       - name: Grant executable permission
         run: chmod +x ./scripts/build.sh
-       
+
       - name: Build WSA GAPPS ${{ matrix.root }} ${{ matrix.arch }}
-        run:  ./scripts/build.sh --arch ${{ matrix.arch }} --release-type ${{ matrix.release }} --magisk-ver stable --gapps-brand ${{ matrix.gapps }} --remove-amazon --root-sol ${{ matrix.root }} --compress
-    
+        id: wsa
+        run: ./scripts/build.sh --arch ${{ matrix.arch }} --release-type ${{ matrix.release }} --magisk-ver stable --gapps-brand ${{ matrix.gapps }} --root-sol ${{ matrix.root }} --remove-amazon --compress-format ${{ matrix.compress-format }}
+
       - name: Prepare release tag
         id: date
         run: echo "date=$(date +'v%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Upload build to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@master
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./output/*
-          name: ${{ steps.date.outputs.date }}
+          file: ./output/${{ steps.wsa.outputs.artifact }}.${{ matrix.compress-format }}
           tag: ${{ steps.date.outputs.date }}
           overwrite: true
           file_glob: true
-
-

--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -16,59 +16,68 @@ on:
         default: "retail"
       magisk-ver:
         type: choice
-        description:  Magisk version.
+        description: Magisk version.
         required: true
         options: ["stable","beta","canary","debug"]
         default: "stable"
       gapps-brand:
         type: choice
-        description:  GApps brand. none for no integration of GApps
+        description: GApps brand. none for no integration of GApps
         required: true
         options: ["OpenGApps","MindTheGapps","none"]
         default: "MindTheGapps"
       gapps-variant:
         type: choice
-        description:  GApps variant.
+        description: GApps variant.
         required: true
         options: ["super","stock","full","mini","micro","nano","pico","tvstock","tvmini"]
         default: "pico"
       root-sol:
         type: choice
-        description:  Root solution. none means no root.
+        description: Root solution. none means no root.
         required: true
-        options: [ "magisk","none"]
+        options: ["magisk","none"]
         default: "magisk"
 #       remove-amazon:
 #         description: Remove Amazon Appstore from the system
 #         required: true
 #         type: boolean 
-#         default: true        
+#         default: true
+      compress-format:
+        type: choice
+        description: Compress format.
+        required: true
+        options: ["zip","7z","xz"]
+        default: "7z"
 
 jobs:
   custbuild:
     name: Build WSA
     runs-on: ubuntu-latest
-        
-    steps:         
+
+    steps:
       - name: Checkout ♻️
         uses: actions/checkout@v3
-        
+
       - name: Install Dependencies 🧑‍🏭
         run: |
-          sudo apt-get update
-          sudo apt-get install -y whiptail setools lzip wine winetricks patchelf e2fsprogs python3-pip aria2 p7zip-full attr
+          sudo apt-get update -y
+          sudo apt-get install -y whiptail setools lzip wine patchelf e2fsprogs python3-pip aria2 p7zip-full attr xz-utils unzip cabextract
+          sudo wget -P /usr/local/bin/ https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
+          sudo chmod +x /usr/local/bin/winetricks
+          wget -P /home/runner/.cache/winetricks/msxml6/ https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/wine/.cache/winetricks/msxml6/msxml6-KB973686-enu-amd64.exe
           pip list --disable-pip-version-check | grep -E "^requests " >/dev/null 2>&1 || python3 -m pip install requests
           winetricks list-installed | grep -E "^msxml6" >/dev/null 2>&1 || winetricks msxml6 || abort
-      
+
       - name: Grant exec permission to script 👑
         run: chmod +x ./scripts/build.sh
-      
+
       - name: Build WSA 🏗️
         id: wsa
-        run: ./scripts/build.sh --arch ${{ inputs.arch }} --release-type ${{ inputs.release-type }} --magisk-ver ${{ inputs.magisk-ver }} --gapps-brand ${{ inputs.gapps-brand }} --gapps-variant ${{ inputs.gapps-variant }} --root-sol ${{ inputs.root-sol }} --remove-amazon --compress
-      
+        run: ./scripts/build.sh --arch ${{ inputs.arch }} --release-type ${{ inputs.release-type }} --magisk-ver ${{ inputs.magisk-ver }} --gapps-brand ${{ inputs.gapps-brand }} --gapps-variant ${{ inputs.gapps-variant }} --root-sol ${{ inputs.root-sol }} --remove-amazon --compress-format ${{ inputs.compress-format }}
+
       - name: Upload Artifact 🤌
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.wsa.outputs.artifact }}
-          path: ./output/${{ steps.wsa.outputs.artifact }}.7z
+          path: ./output/${{ steps.wsa.outputs.artifact }}.${{ inputs.compress-format }}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,7 +93,7 @@ abort() {
 trap abort INT TERM
 
 Gen_Rand_Str() {
-    tr -dc '[:lower:]' </dev/urandom | fold -w "$1" | head -n 1
+    haveged -n $((${1:-32}*512)) --file - 2>/dev/null | tr -dc '[:lower:]' | fold -w "$1" | head -n 1
 }
 
 default() {
@@ -911,6 +911,7 @@ if [ "$REMOVE_AMAZON" = "yes" ]; then
     artifact_name+="-RemovedAmazon"
 fi
 echo "$artifact_name"
+echo "artifact=$(echo "$artifact_name")" >> $GITHUB_OUTPUT
 echo -e "\nFinishing building...."
 if [ -f "$OUTPUT_DIR" ]; then
     $SUDO rm -rf "${OUTPUT_DIR:?}"


### PR DESCRIPTION
- Use latest Winetricks package + necessary cabextract for it
- Add missing xz-utils and unzip, they were later added to run.sh as needed dependencies
- Manually download msxml6 from repo to avoid occasional download falling
- Add automatic yes to prompts for `sudo apt-get update` too
- Add compress-format to build.yml and custom_build.yml
- Use haveged instead of /dev/urandom for Gen_Rand_Str
- Add back environment variable for $GITHUB_OUTPUT, otherwise custom_build.yml will fail to upload the artifact
- Use `${{ steps.wsa.outputs.artifact }}` for build.yml too
- Use master branch for svenstaro/upload-release-action to get rid of Node 12 and `set-output` deprecation warnings
- Minor fixes + formatting